### PR TITLE
Enable to acquire the configured capture image resolution from V4LCameraCapture

### DIFF
--- a/example/uvccamera
+++ b/example/uvccamera
@@ -11,11 +11,12 @@ from actfw.task import Pipe, Consumer
 
 class Converter(Pipe):
 
-    def __init__(self):
+    def __init__(self, capture_size):
         super(Converter, self).__init__()
+        self.capture_size = capture_size
 
     def proc(self, frame):
-        rgb_image = Image.frombuffer('RGB', (CAPTURE_WIDTH, CAPTURE_HEIGHT), frame.getvalue(), 'raw', 'RGB')
+        rgb_image = Image.frombuffer('RGB', self.capture_size, frame.getvalue(), 'raw', 'RGB')
         gray_image = rgb_image.convert('L')
         return (rgb_image, gray_image)
 
@@ -47,20 +48,20 @@ def main(args):
     # Load act setting
     settings = app.get_settings({'display': True})
 
+    # CommandServer (for `Take Photo` command)
+    cmd = actfw.CommandServer()
+    app.register_task(cmd)
+
+    # Capture task
+    cap = actfw.capture.V4LCameraCapture('/dev/video0', (CAPTURE_WIDTH, CAPTURE_HEIGHT), 30)
+    capture_size = cap.capture_size()
+    app.register_task(cap)
+
+    # Converter task
+    conv = Converter(capture_size)
+    app.register_task(conv)
+
     def run(preview=None):
-
-        # CommandServer (for `Take Photo` command)
-        cmd = actfw.CommandServer()
-        app.register_task(cmd)
-
-        # Capture task
-        cap = actfw.capture.V4LCameraCapture('/dev/video0', (CAPTURE_WIDTH, CAPTURE_HEIGHT), 30)
-        app.register_task(cap)
-
-        # Converter task
-        conv = Converter()
-        app.register_task(conv)
-
         # Presenter task
         pres = Presenter(preview, cmd)
         app.register_task(pres)
@@ -76,7 +77,8 @@ def main(args):
         with Display() as display:
             width, height = display.size()
             with display.open_window((0, 0, width, height), (32, 1), 1000) as background:
-                with display.open_window(((width-DISPLAY_WIDTH)//2, (height-DISPLAY_HEIGHT)//2, DISPLAY_WIDTH, DISPLAY_HEIGHT), (CAPTURE_WIDTH, CAPTURE_HEIGHT), 2000) as preview:
+                with display.open_window(((width-DISPLAY_WIDTH)//2, (height-DISPLAY_HEIGHT)//2, DISPLAY_WIDTH, DISPLAY_HEIGHT), capture_size, 2000) as preview:
+
                     run(preview)
     else:
         run()


### PR DESCRIPTION
If UVC camera does not support expected capture resolution, V4LCameraCapture configure to set more large capture resolution than expected one. And then, we can acquire the configured resolution from V4LCameraCapture object.