### PR TITLE
fix Producer._inlet to be infinite generator

### DIFF
--- a/actfw/task/producer.py
+++ b/actfw/task/producer.py
@@ -14,4 +14,5 @@ class Producer(Pipe):
         raise NotImplementedError('This is producer')
 
     def _inlet(self):
-        yield ()
+        while self._is_running():
+            yield ()


### PR DESCRIPTION
[`Pipe.run`](https://github.com/Idein/actcast-app-python/blob/80d24b3e2220167f2a1d0b2767b7d39b5c87cbcf/actfw/task/pipe.py#L58) uses [`Pipe._inlet`](https://github.com/Idein/actcast-app-python/blob/80d24b3e2220167f2a1d0b2767b7d39b5c87cbcf/actfw/task/pipe.py#L60) which works as generator.

[`Producer`](https://github.com/Idein/actcast-app-python/blob/80d24b3e2220167f2a1d0b2767b7d39b5c87cbcf/actfw/task/producer.py#L4) is a subclass of `Pipe`. Current `Producer._inlet` generator generates only 1 `()` and terminates. This is unexpected behavior. It should generate `()` one after another until an application is stopped.